### PR TITLE
Proposed corrections to PR#89 with bugfixes/de-duplication of code

### DIFF
--- a/adsft/extraction.py
+++ b/adsft/extraction.py
@@ -480,6 +480,16 @@ class StandardExtractorXML(object):
             # - A processing instruction is coded like this: <?ignore .... what ever I want here, including <!-- comments --> ...  ?>
             #   RegEx Source: https://stackoverflow.com/a/29418829/6940788
             raw_xml = re.sub('<\?[^>]+\?>', '', raw_xml) # Processing instructions
+        if parser_name in ("html5lib",):
+            # - Convert self closing xml tags to closing tags
+            #   Source: https://stackoverflow.com/a/14028108
+            # - html5lib will close them itself (unless it is a recognised html
+            #   tag) at a later point in the document, wrapping other content,
+            #   and if it turns out to be a tag that we want to remove
+            #   (i.e., graphics), we will wrongly remove the content that was
+            #   wrapped
+            raw_xml = re.sub('<\s*([^\s>]+)([^>]*)/\s*>', r'<\1\2></\1>', raw_xml) # Self closing tags (e.g., <graphics/>) to closing tabs (e.g., <graphics></graphics>)
+
         return raw_xml
 
     def _save_body_tag(self, raw_xml):

--- a/adsft/extraction.py
+++ b/adsft/extraction.py
@@ -682,14 +682,6 @@ class StandardExtractorXML(object):
             # and restore the original body tag
             parsed_xml = self._restore_body_tag(parsed_xml, random_body_tag)
 
-        # remove tables, formulas, figures and bibliography
-        for e in parsed_xml.xpath("//table | //graphic | //disp-formula | ////inline-formula | //formula | //tex-math | //processing-instruction('CDATA') | //bibliography"):
-            self._remove_keeping_tail(e)
-
-        # move acknowledgments after body (most likely only a minority of documents have this problem)
-        for e in parsed_xml.xpath(" | ".join(META_CONTENT['xml']['acknowledgements']['xpath'])):
-            self._append_tag_outside_parent(e)
-
         if parser_name in ("lxml-xml", "direct-lxml-xml") and parsed_xml.nsmap:
             # These parsers detect namespaces and expand the namespace prefixes
             # into their namespace, we need to remove them to make xpath work
@@ -702,6 +694,15 @@ class StandardExtractorXML(object):
             # (e.g., 'xlink:href'), we need to remove them to make xpath work
             # without having to specify the namespace prefixes
             parsed_xml = self._remove_namespace_prefixes(parsed_xml)
+
+        # remove tables, formulas, figures and bibliography
+        for e in parsed_xml.xpath("//table | //graphic | //disp-formula | ////inline-formula | //formula | //tex-math | //processing-instruction('CDATA') | //bibliography"):
+            self._remove_keeping_tail(e)
+
+        # move acknowledgments after body (most likely only a minority of documents have this problem)
+        for e in parsed_xml.xpath(" | ".join(META_CONTENT['xml']['acknowledgements']['xpath'])):
+            self._append_tag_outside_parent(e)
+
 
         return parsed_xml
 

--- a/adsft/tests/test_extraction.py
+++ b/adsft/tests/test_extraction.py
@@ -711,7 +711,7 @@ class TestXMLElsevierExtractor(test_base.TestUnit):
         full_text_content = self.extractor.open_xml()
 
         if self.parsers:
-            for parser_name in ("lxml-xml",): # this is the only parser that works for this unit test
+            for parser_name in self.parsers:
                 self.extractor.parse_xml(preferred_parser_names=(parser_name,))
                 section = self.extractor.extract_string('//body//section[@id="s3"]//para')
                 self.assertEqual(section, u'THIS SECTION TESTS THAT THE TAIL IS PRESERVED .')

--- a/config.py
+++ b/config.py
@@ -12,6 +12,7 @@ EXTRACT_PDF_SCRIPT = '/scripts/extract_pdf_with_pdftotext.sh'
 OUTPUT_CELERY_BROKER = 'pyamqp://guest:guest@localhost:6672/master_pipeline'
 OUTPUT_TASKNAME = 'adsmp.tasks.task_update_record'
 
+PREFERRED_XML_PARSER_NAMES = ("html5lib", "html.parser", "lxml-html", "direct-lxml-html", "lxml-xml", "direct-lxml-xml",)
 
 FULLTEXT_EXTRACT_PATH = './live'
 


### PR DESCRIPTION
This PR is intended to address and showcase solutions to the concerns shared in https://github.com/adsabs/ADSfulltext/pull/89. In particular, this PR includes the following changes:
- html5lib fails with non-HTML tags that are self-closing, added regex to convert self-closing to closing tags when that parser is used
- Recovered parser iterations that were lost with the PR
- Merged unit tests that were asserting the body and iterate through all the parsers
- Corrected acknowledgement test that was missing the assert part
- Bugfix: Removal of elements should happen after namespaces have been corrected
- List of XML parser are now defined in config.py
- Removed duplicated code in test showcasing how the centralized parsers list can keep the unit tests iterating through all the parsers while the developer still has the option to change the behavior (as requested by @krisbukovi in private conversation)
- Recovered original parsers order since the order was changed only to overcome the self-closing issue that the html5lib parser had (but now that issue has been fixed in this PR) and so far we do not have any quantitative evidence of which parsers should be prioritized to optimize the full text extraction of our corpus
